### PR TITLE
Redo scaling of coeffs.

### DIFF
--- a/PowerAmplifier.m
+++ b/PowerAmplifier.m
@@ -1,207 +1,217 @@
 classdef PowerAmplifier
-   %PowerAmplifier Construct a PA and broadcast.
-   
-   properties
-      PolyCoeffs
-      create_model
-      order
-      memory_depth
-      mse_of_fit
-      sparsity_factor
-      node_tx
-      use_orthogonal
-   end
-   properties (Constant)
-      WienerFilter_B = [1;0.2];
-      WienerFilter_A = [1;-0.1];
-   end
-   
-   methods
-      function obj = PowerAmplifier(create_model, signal, order, memory_depth, use_orthogonal)
-         %POWERAMPLIFIER Construct an instance of this class
-         %
-         % Args:
-         %     create_model: 1 or 0. Tells it to use lms learning on input/output relationship of signal.
-         %     order:   int with PA order. Should be odd. 1, 3, 5, etc.
-         %     memory_depth: int with number of taps in FIR filter
-         
-         if nargin == 0
-            return; 
-         end
-         
-         obj.create_model = create_model;
-         obj.order = order;
-         obj.memory_depth = memory_depth;
-         obj.sparsity_factor = 1;
-         obj.node_tx.serialNumber = 9999;  %Serial number to avoid error when running code with no board.
-         obj.use_orthogonal = use_orthogonal;
-         
-         if obj.create_model
-            obj = obj.perform_lms_learning(signal);
-         else
-            % Wiener Power Amplifier Model
-            PolyOrder   = 5;        % PA polynomial order
-            G_PA        = 25;       % PA gain in dB
-            IIP3        = 17;       % PA IIP3 in dBm
-            P_1dBOut_dB = 26.5;     % PA output 1-dB compression point in dBm
-            obj.PolyCoeffs = obj.PA_poly_parameters(G_PA, IIP3, P_1dBOut_dB, PolyOrder);
-         end
-      end
-      
-      function obj = perform_lms_learning(obj, signal)
-         %perform_lms_learning	Learn a PA model
-         %	obj.perform_lms_learning(signal) finds the best LS fit for a PH
-         %	power amplifier. The signal is expected to be a class with post
-         %	and pre PA data.
-         %
-         %  The LS regression solution is standard. Can be derrived by
-         %  doing the sum_i [y_i - (beta_0 x_i + beta_! x_i)^2]
-         %  optimization. The PA model is linear with respect to the
-         %  coefficients. 
-         %
-         %	Author:	Chance Tarver (2018)
-         %		tarver.chance@gmail.com
-         %
-         
-         
-         % Construct signal matrix with basis vectors for each nonlinearity
-         x = signal.pre_pa.upsampled_td;
-         y = signal.post_pa.upsampled_td;
-         
-         number_of_basis_vectors = obj.memory_depth * (obj.order + 1)/2;
-         X = zeros(length(signal.pre_pa.upsampled_td), number_of_basis_vectors);
-         
-         count = 1;
-         for i = 1:2:obj.order
-            branch = x .* abs(x).^(i-1);
-            for j = 1:obj.memory_depth
-               delayed_version = zeros(size(branch));
-               delayed_version((j-1)*obj.sparsity_factor + 1:end) = branch(1:end - (j-1)*obj.sparsity_factor);
-               X(:, count) = delayed_version;
-               count = count + 1;
+    %PowerAmplifier Construct a PA and broadcast.
+    
+    properties
+        PolyCoeffs
+        create_model
+        order
+        memory_depth
+        mse_of_fit
+        sparsity_factor
+        node_tx
+        use_orthogonal
+    end
+    properties (Constant)
+        WienerFilter_B = [1;0.2];
+        WienerFilter_A = [1;-0.1];
+    end
+    
+    methods
+        function obj = PowerAmplifier(create_model, signal, order, memory_depth, use_orthogonal)
+            %POWERAMPLIFIER Construct an instance of this class
+            %
+            % Args:
+            %     create_model: 1 or 0. Tells it to use lms learning on input/output relationship of signal.
+            %     order:   int with PA order. Should be odd. 1, 3, 5, etc.
+            %     memory_depth: int with number of taps in FIR filter
+            
+            if nargin == 0
+                return;
             end
-         end
-         if obj.use_orthogonal
-            X = orth(X);
-            obj.PolyCoeffs = (X'*X) \ (X'*y);
-         else
-             obj.PolyCoeffs = ((X'*X)+1e-13*eye(size((X'*X)))) \ (X'*y) ;
-         end
-         obj.PolyCoeffs = (X'*X) \ (X'*y);
-         model_pa_output = obj.transmit(x);
-         
-         %obj.mse_of_fit = mean(abs(y-model_pa_output).^2);
-         obj.mse_of_fit = norm(y - model_pa_output)^2 / norm(y)^2;
-         
-         % For looking at the MSE of the model.
-         %error_vector = y - model_pa_output;
-         %mean(error_vector)
-         %std(error_vector)
-         
-         
-      end
-      
-      function pa_output = transmit(obj, in)
-         %transmit	Broadcast the input data using the PA model stored in
-         %the object
-         %
-         %	obj.transmit(in) send in through the PH model that is stored in
-         %	the object. It expands the input into a matrix where the columns
-         %  are the different nonlinear branches or delayed versions of the
-         %  nonlinear branches to model the FIR filter. A product can
-         %  be done with the coefficient to get the PA output.
-         %	 
-         %
-         %	Author:	Chance Tarver (2018)
-         %		tarver.chance@gmail.com
-         %         
-         if obj.create_model
+            
+            obj.create_model = create_model;
+            obj.order = order;
+            obj.memory_depth = memory_depth;
+            obj.sparsity_factor = 1;
+            obj.node_tx.serialNumber = 9999;  %Serial number to avoid error when running code with no board.
+            obj.use_orthogonal = use_orthogonal;
+            
+            if obj.create_model
+                obj = obj.perform_lms_learning(signal);
+            else
+                % Wiener Power Amplifier Model
+                PolyOrder   = 5;        % PA polynomial order
+                G_PA        = 25;       % PA gain in dB
+                IIP3        = 17;       % PA IIP3 in dBm
+                P_1dBOut_dB = 26.5;     % PA output 1-dB compression point in dBm
+                obj.PolyCoeffs = obj.PA_poly_parameters(G_PA, IIP3, P_1dBOut_dB, PolyOrder);
+            end
+        end
+        
+        
+        function obj = perform_lms_learning(obj, signal)
+            %perform_lms_learning	Learn a PA model
+            %	obj.perform_lms_learning(signal) finds the best LS fit for a PH
+            %	power amplifier. The signal is expected to be a class with post
+            %	and pre PA data.
+            %
+            %  The LS regression solution is standard. Can be derrived by
+            %  doing the sum_i [y_i - (beta_0 x_i + beta_! x_i)^2]
+            %  optimization. The PA model is linear with respect to the
+            %  coefficients.
+            %
+            %	Author:	Chance Tarver (2018)
+            %		tarver.chance@gmail.com
+            %
+            
+            % Construct signal matrix with basis vectors for each nonlinearity
+            x = signal.pre_pa.upsampled_td;
+            y = signal.post_pa.upsampled_td;
+            
+            %x = x / rms(x);
+            %scale_factor =  norm(x) / norm(signal.pre_pa.upsampled_td);
+            %y = y * scale_factor;
+            
+            X = obj.setup_basis_matrix(x);            
+
+            obj.PolyCoeffs = ((X'*X)+1e-13*eye(size((X'*X)))) \ (X'*y) ;
+            
+            %obj.PolyCoeffs = (X'*X) \ (X'*y);
+            model_pa_output = obj.transmit(x);
+            
+            %obj.mse_of_fit = mean(abs(y-model_pa_output).^2);
+            obj.mse_of_fit = norm(y - model_pa_output)^2 / norm(y)^2;
+            
+            % For looking at the MSE of the model.
+            %error_vector = y - model_pa_output;
+            %mean(error_vector)
+            %std(error_vector)
+        end
+        
+        
+        function pa_output = transmit(obj, in)
+            %transmit	Broadcast the input data using the PA model stored in
+            %the object
+            %
+            %	obj.transmit(in) send in through the PH model that is stored in
+            %	the object. It expands the input into a matrix where the columns
+            %  are the different nonlinear branches or delayed versions of the
+            %  nonlinear branches to model the FIR filter. A product can
+            %  be done with the coefficient to get the PA output.
+            %
+            %
+            %	Author:	Chance Tarver (2018)
+            %		tarver.chance@gmail.com
+            %
+            
+            %in = in / rms(in);
+            
+            if obj.create_model
+                X = obj.setup_basis_matrix(in);
+                pa_output = X * obj.PolyCoeffs;
+                
+            else
+                %wiener_transmit Transmit over a Weiner PA model
+                %Scale to unit input.
+                larger_signal = 0.41  * in /mean(abs(in)); % This scaling was choosen to make the AM/AM curve look nice with a little bit of saturation at the top.
+                PAinFiltered = filter(obj.WienerFilter_B, obj.WienerFilter_A, larger_signal);
+                
+                PolyOrder = 2*length(obj.PolyCoeffs) - 1;
+                
+                FilteredBasisFunctions = zeros(length(PAinFiltered),(PolyOrder+1)/2);
+                for k=1:2:PolyOrder
+                    FilteredBasisFunctions(:,(k+1)/2) = PAinFiltered.*abs(PAinFiltered).^(k-1);
+                end
+                unnormalized_output = FilteredBasisFunctions * obj.PolyCoeffs;
+                pa_output = unnormalized_output*norm(in)/norm(unnormalized_output);
+            end
+        end
+        
+        
+        function X = setup_basis_matrix(obj, x)
+            
             number_of_basis_vectors = obj.memory_depth * (obj.order + 1)/2;
-            X = zeros(length(in), number_of_basis_vectors);
+            X = zeros(length(x), number_of_basis_vectors);
             
             count = 1;
             for i = 1:2:obj.order
-               branch = in .* abs(in).^(i-1);
-               for j = 1:obj.memory_depth
-                  delayed_version = zeros(size(branch));
-                  delayed_version(j * obj.sparsity_factor:end) = branch(1:end - j*obj.sparsity_factor + 1);
-                  X(:, count) = delayed_version;
-                  count = count + 1;
-               end
+                branch = x .* abs(x).^(i-1);
+                for j = 1:obj.memory_depth
+                    delayed_version = zeros(size(branch));
+                    delayed_version((j-1)*obj.sparsity_factor + 1:end) = branch(1:end - (j-1)*obj.sparsity_factor);
+                    X(:, count) = delayed_version;
+                    count = count + 1;
+                end
             end
             
             if obj.use_orthogonal
-                X = orth(X);
+                if count-1 == 1
+                else
+                    Z = orth(X);
+                    for i = 1:count-1
+                        original_mag_of_current_column = norm(X(:,i));
+                        Z(:,i) = original_mag_of_current_column * Z(:,i);
+                    end
+                    X = Z;
+                end
             end
+        end
+        
+        
+        function [param] = PA_poly_parameters(obj, G_dB, IIP3_dB, P_1dBOut_dB, PolyOrder)
+            % PA polynomial parameter calculation based on PA gain, IIP3, and 1-dB compression point
             
-            pa_output = X * obj.PolyCoeffs;
+            % G_dB = 0; % PA gain in dB; compare with alfa1 below
+            % IIP3 = 15; % [dBm]
+            iip3 = 10^(IIP3_dB/10);
+            % P_1dBOut_dB = 20;  % PA output 1-dB compression point; [dB]
+            P_1dBOut = (10^(P_1dBOut_dB/10));
+            P_1dBIn = (10^((P_1dBOut_dB-G_dB+1)/10));
+            % P_1dBIn_dB = 10*log10(P_1dBIn);
             
-         else
-            %wiener_transmit Transmit over a Weiner PA model
-            %Scale to unit input.
-            larger_signal = 0.41  * in /mean(abs(in)); % This scaling was choosen to make the AM/AM curve look nice with a little bit of saturation at the top.
-            PAinFiltered = filter(obj.WienerFilter_B, obj.WienerFilter_A, larger_signal);
+            alfa1 = 10^(G_dB/20);
+            alfa3 = -alfa1/iip3*exp(1i*0.2986);
+            alfa5 = (sqrt(P_1dBOut)-alfa1*sqrt(P_1dBIn)-alfa3*sqrt(P_1dBIn)^3)/(sqrt(P_1dBIn)^5);
             
-            PolyOrder = 2*length(obj.PolyCoeffs) - 1;
-            
-            FilteredBasisFunctions = zeros(length(PAinFiltered),(PolyOrder+1)/2);
-            for k=1:2:PolyOrder
-               FilteredBasisFunctions(:,(k+1)/2) = PAinFiltered.*abs(PAinFiltered).^(k-1);
+            if PolyOrder == 5
+                param = [alfa1;alfa3;alfa5];
+            else
+                param = [alfa1;alfa3];
             end
-            unnormalized_output = FilteredBasisFunctions * obj.PolyCoeffs;
-            pa_output = unnormalized_output*norm(in)/norm(unnormalized_output);
-         end
-      end
-      function [param] = PA_poly_parameters(obj, G_dB, IIP3_dB, P_1dBOut_dB, PolyOrder)
-         % PA polynomial parameter calculation based on PA gain, IIP3, and 1-dB compression point
-         
-         % G_dB = 0; % PA gain in dB; compare with alfa1 below
-         % IIP3 = 15; % [dBm]
-         iip3 = 10^(IIP3_dB/10);
-         % P_1dBOut_dB = 20;  % PA output 1-dB compression point; [dB]
-         P_1dBOut = (10^(P_1dBOut_dB/10));
-         P_1dBIn = (10^((P_1dBOut_dB-G_dB+1)/10));
-         % P_1dBIn_dB = 10*log10(P_1dBIn);
-         
-         alfa1 = 10^(G_dB/20);
-         alfa3 = -alfa1/iip3*exp(1i*0.2986);
-         alfa5 = (sqrt(P_1dBOut)-alfa1*sqrt(P_1dBIn)-alfa3*sqrt(P_1dBIn)^3)/(sqrt(P_1dBIn)^5);
-         
-         if PolyOrder == 5
-            param = [alfa1;alfa3;alfa5];
-         else
-            param = [alfa1;alfa3];
-         end
-      end
-      function out = up_sample(obj, in)
-         %up_sample	Wrapper to upsample and filter for PA transmission.
-         %	 
-         %
-         %	Author:	Chance Tarver (2018)
-         %		tarver.chance@gmail.com
-         %  
-         rrcFilter = rcosdesign(0.25, 60, obj.upsample_rate);
-         out = upfirdn(in, rrcFilter, obj.upsample_rate);
-      end
-      function out = down_sample(obj, in)
-         %down_sample	Wrapper to downsample and antialias filter. Also
-         %corrects for the filter timing.
-         %	 
-         %
-         %	Author:	Chance Tarver (2018)
-         %		tarver.chance@gmail.com
-         %  
-         
-         % Anti alias filter
-         b = firls(100, [0 0.8/obj.upsample_rate 1/obj.upsample_rate 1], [1 1 0 0]);
-         filtered_signal = filter(b, 1, in);
-         
-         compensate_for_filter_timing = filtered_signal(51:end);
-         compensate_for_upsampling_rrc = compensate_for_filter_timing(301:end);
-         
-         % Downsampling
-         out = downsample(compensate_for_upsampling_rrc, obj.upsample_rate);
-         out = out(1:512);
-      end
-   end
+        end
+        
+        
+        function out = up_sample(obj, in)
+            %up_sample	Wrapper to upsample and filter for PA transmission.
+            %
+            %
+            %	Author:	Chance Tarver (2018)
+            %		tarver.chance@gmail.com
+            %
+            rrcFilter = rcosdesign(0.25, 60, obj.upsample_rate);
+            out = upfirdn(in, rrcFilter, obj.upsample_rate);
+        end
+        
+        
+        function out = down_sample(obj, in)
+            %down_sample	Wrapper to downsample and antialias filter. Also
+            %corrects for the filter timing.
+            %
+            %
+            %	Author:	Chance Tarver (2018)
+            %		tarver.chance@gmail.com
+            %
+            
+            % Anti alias filter
+            b = firls(100, [0 0.8/obj.upsample_rate 1/obj.upsample_rate 1], [1 1 0 0]);
+            filtered_signal = filter(b, 1, in);
+            
+            compensate_for_filter_timing = filtered_signal(51:end);
+            compensate_for_upsampling_rrc = compensate_for_filter_timing(301:end);
+            
+            % Downsampling
+            out = downsample(compensate_for_upsampling_rrc, obj.upsample_rate);
+            out = out(1:512);
+        end
+    end
 end

--- a/PowerAmplifier.m
+++ b/PowerAmplifier.m
@@ -92,6 +92,13 @@ classdef PowerAmplifier
          
          %obj.mse_of_fit = mean(abs(y-model_pa_output).^2);
          obj.mse_of_fit = norm(y - model_pa_output)^2 / norm(y)^2;
+         
+         % For looking at the MSE of the model.
+         %error_vector = y - model_pa_output;
+         %mean(error_vector)
+         %std(error_vector)
+         
+         
       end
       
       function pa_output = transmit(obj, in)

--- a/PowerAmplifier.m
+++ b/PowerAmplifier.m
@@ -65,15 +65,15 @@ classdef PowerAmplifier
             %
             
             % Construct signal matrix with basis vectors for each nonlinearity
-            x = signal.pre_pa.upsampled_td;
-            y = signal.post_pa.upsampled_td;
+            x = signal.pre_pa.up_td_scaled;
+            y = signal.post_pa.up_td_scaled;
             
             %x = x / rms(x);
             %scale_factor =  norm(x) / norm(signal.pre_pa.upsampled_td);
             %y = y * scale_factor;
             
-            X = obj.setup_basis_matrix(x);            
-
+            X = obj.setup_basis_matrix(x);
+            
             obj.PolyCoeffs = ((X'*X)+1e-13*eye(size((X'*X)))) \ (X'*y) ;
             
             %obj.PolyCoeffs = (X'*X) \ (X'*y);

--- a/Signal.m
+++ b/Signal.m
@@ -24,6 +24,7 @@ classdef Signal
             out = upfirdn(in, obj.tools.upsample_rrcFilter, obj.settings.upsample_rate);
         end
         
+        
         function out = down_sample(obj, in)
             
             % Anti alias filter
@@ -39,8 +40,8 @@ classdef Signal
             out = out(1:obj.settings.fft_size*obj.settings.number_of_symbols);
         end
         
+        
         function obj = calculate_PAPR(obj)
-            
             % EVM
             error_vector = obj.post_pa.fd_symbols - obj.pre_pa.frequency_domain_symbols;
             max_reference = max(abs(obj.pre_pa.frequency_domain_symbols));
@@ -70,6 +71,19 @@ classdef Signal
             title('CCDF'),axis([0 14 1e-5 1])
         end
         
+        
+        function [out, scale_factor] = normalize_for_pa(obj, in, RMS_power)
+            scale_factor = RMS_power/rms(in);
+            out = in * scale_factor;
+            if abs(rms(out) - RMS_power) > 0.01
+                error('RMS is wrong.');
+            end
+            
+            max_real = max(abs(real(out)));
+            max_imag = max(abs(imag(out)));
+            max_max = max(max_real, max_imag);
+            fprintf('Maximum value: %1.2f\n', max_max);
+        end
     end
 end
 

--- a/WARP.m
+++ b/WARP.m
@@ -157,12 +157,13 @@ classdef WARP  < handle
             txData1 = txData1 - obj.dc.real - obj.dc.imag*j;
             
             %Normalize for TX
-            max_amplitude = 0.7;
             max_real = max(abs(real(txData1)));
             max_imag = max(abs(imag(txData1)));
             max_max = max(max_real, max_imag);
+            if max_max > 0.95
+                error('Saturating DAC of WARP.');
+            end
             
-            txData1 = txData1 * max_amplitude / max_max;
             
             % Loop to get the right gain setting on RX.
             while(1)

--- a/WARP.m
+++ b/WARP.m
@@ -214,6 +214,7 @@ classdef WARP  < handle
             end
             
             out = rx_iq * norm(original_signal_input) / norm(rx_iq);
+            %out = rx_iq * sum(abs(original_signal_input)) / sum(abs(rx_iq));
             
             if  obj.synchronization.sub_sample
                 %Set up a LS estimation for figuring out a subsample delay.

--- a/evaluate_pa_models.m
+++ b/evaluate_pa_models.m
@@ -1,4 +1,4 @@
-function pa_models = evaluate_pa_models(signal,number)
+function pa_models = evaluate_pa_models(signal, number)
 %evaluate_pa_models Create models with different nonlinear orders and
 %memory depths. Plot the MSE of each and return a good model.
 
@@ -13,7 +13,7 @@ mse_transpose = zeros(MAX_MEMORY_ORDER, (MAX_NONLINEAR_ORDER+1)/2); %Row major f
 
 counter = 1;
 for i = 1:2:MAX_NONLINEAR_ORDER
-    for j = 1:MAX_MEMORY_ORDER      
+    for j = 1:MAX_MEMORY_ORDER
         pa_models(i,j) = PowerAmplifier(1, signal, i, j, USE_ORTHOGONAL);
         mse_transpose(counter) = pa_models(i,j).mse_of_fit;
         counter = counter + 1;

--- a/main.m
+++ b/main.m
@@ -7,7 +7,6 @@ clear; clc; close all;
 %     + SNR
 %     + ACLR
 % - Crest Factor Reduction
-% - Investigate White Noise Scaling
 % - Investigate the sensitivity of the coeffs
 % - Why do coeffs have 180deg variability?
 
@@ -19,6 +18,7 @@ params.signal_type = 'OFDM';    % either 'OFDM' or 'WGN' or 'CA'
 params.use_random_signal = 1;  % 1 forces a new OFDM each time. 0 will use the same random OFDM signal
 params.signal_bw = 5;          % Bandwidth of the OFDM of WGN signal
 params.channel = 1+0i;
+params.RMS_power = 0.25;
 
 %Only used in OFDM
 params.constellation = 'QPSK'; % Only used in OFDM
@@ -30,18 +30,18 @@ params.number_of_samples = 10000;
 [board, signal] =  setup(params);
 
 % TX
-signal = signal.transmit(board, params.channel);
+signal = signal.transmit(board, params.channel, params.RMS_power);
 
 pa_models = evaluate_pa_models(signal, board.node_tx.serialNumber);
 pa_tables = PA_Tables(pa_models);
 
 %% Plots
 try
-    plot_results('psd', 'PA Input', signal.pre_pa.upsampled_td, signal.settings.sampling_rate * signal.settings.upsample_rate);
-    plot_results('psd', 'PA Output', signal.post_pa.upsampled_td, signal.settings.sampling_rate * signal.settings.upsample_rate);
+    plot_results('psd', 'PA Input', signal.pre_pa.up_td_scaled, signal.settings.sampling_rate * signal.settings.upsample_rate);
+    plot_results('psd', 'PA Output', signal.post_pa.up_td_scaled, signal.settings.sampling_rate * signal.settings.upsample_rate);
     
-    plot_results('am/am', 'Original Signal', signal.pre_pa.upsampled_td, signal.post_pa.upsampled_td);
-    plot_results('model', '7th Order, 4 Taps', pa_models(7,4).transmit(signal.pre_pa.upsampled_td), signal.pre_pa.upsampled_td);
+    plot_results('am/am', 'Original Signal', signal.pre_pa.up_td_scaled, signal.post_pa.up_td_scaled);
+    plot_results('model', '7th Order, 4 Taps', pa_models(7,4).transmit(signal.pre_pa.up_td_scaled), signal.pre_pa.up_td_scaled);
     
     plot_results('constellation', 'Original Symbols', signal.pre_pa.frequency_domain_symbols);
     plot_results('constellation', 'Received Symbols', signal.post_pa.frequency_domain_symbols);
@@ -64,13 +64,11 @@ end
 
 switch params.signal_type
     case 'OFDM'
-        signal = OFDM(params.signal_bw, params.desired_sampling_rate, ...
-            params.number_of_symbols, params.use_random_signal, params.constellation);
+        signal = OFDM(params);
     case 'CA'
         signal = CarrierAggregation(params.signal_bw, params.desired_sampling_rate, ...
             params.number_of_symbols, params.use_random_signal, params.constellation);
     case 'WGN'
-        signal = WhiteNoise(params.signal_bw, params.desired_sampling_rate, ...
-            params.number_of_samples, params.use_random_signal);
+        signal = WhiteNoise(params);
 end
 end

--- a/main.m
+++ b/main.m
@@ -15,7 +15,7 @@ clear; clc; close all;
 %% Set up the experiment
 params.PA_board = 'WARP';      % either 'WARP', 'webRF', or 'none'
 params.RF_port  = 'A2B';       % Broadcast from RF A to RF B. Can also do 'B2A'
-params.signal_type = 'WGN';    % either 'OFDM' or 'WGN' or 'CA'
+params.signal_type = 'OFDM';    % either 'OFDM' or 'WGN' or 'CA'
 params.use_random_signal = 1;  % 1 forces a new OFDM each time. 0 will use the same random OFDM signal
 params.signal_bw = 5;          % Bandwidth of the OFDM of WGN signal
 params.channel = 1+0i;


### PR DESCRIPTION
New var in the signal.

signal.pre_pa.up_td_scaled
signal.post_pa.up_td_scaled

This new var is scaled to the RMS that is set in the params. I took out the scaling of the max value of the PA input that was in the WARP class and just added a warning in case the DAC is going to be saturated. 
![block](https://user-images.githubusercontent.com/2287409/42523181-98509d24-8432-11e8-9b31-699d6030ce17.PNG)
